### PR TITLE
Pd 1914

### DIFF
--- a/lib/grpc_rest.rb
+++ b/lib/grpc_rest.rb
@@ -101,13 +101,12 @@ module GrpcRest
         next if val.nil?
 
         if descriptor.label == :repeated
-          arr = val.is_a?(Google::Protobuf::RepeatedField) ? val : val.to_s.split(',')
           # leave map entries as key => value
           unless descriptor.subtype&.options&.to_h&.dig(:map_entry)
-            params[field] = arr.map { |v| map_proto_type(descriptor, v) }
+            params[field] = Array.wrap(val).map { |v| map_proto_type(descriptor, v) }
           end
         else
-          params[field] = map_proto_type(descriptor, arr)
+          params[field] = map_proto_type(descriptor, val)
         end
       end
 

--- a/lib/grpc_rest.rb
+++ b/lib/grpc_rest.rb
@@ -101,12 +101,13 @@ module GrpcRest
         next if val.nil?
 
         if descriptor.label == :repeated
+          arr = val.is_a?(Google::Protobuf::RepeatedField) ? val : val.to_s.split(',')
           # leave map entries as key => value
           unless descriptor.subtype&.options&.to_h&.dig(:map_entry)
-            params[field] = val.map { |v| map_proto_type(descriptor, v) }
+            params[field] = arr.map { |v| map_proto_type(descriptor, v) }
           end
         else
-          params[field] = map_proto_type(descriptor, val)
+          params[field] = map_proto_type(descriptor, arr)
         end
       end
 


### PR DESCRIPTION
Use `Array.wrap` to prevent grpc-rest from crashing when query parameters don't have `[]` suffixed.