### PR TITLE
Feature: Forward request headers to the gRPC call as metadata.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
+- Feature: Forward request headers to the gRPC call as metadata.
+- Fix/Change: Update interceptors to pass a Gruf::Controller::Request instead of the raw gRPC request object. This allows e.g. checking metadata inside the interceptor. This is a breaking change.
+
 # 0.3.1 - 2025-07-02
 - Fix: Include full error backtrace in logs
 

--- a/lib/generator/controller.rb.erb
+++ b/lib/generator/controller.rb.erb
@@ -21,7 +21,7 @@ class <%= service.name.demodulize %>Controller < ActionController::Base
       except(*%w(controller action <%= service.name.underscore %>))
     grpc_request = GrpcRest.init_request(<%= method.request_type %>, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["<%= method.name.underscore %>"], "<%= method.option_body %>", request.parameters)
-    render json: GrpcRest.send_request("<%= service.namespace %>::<%= service.name.classify %>", "<%= method.name.underscore %>", grpc_request, <%= method.rest_options.inspect %>)
+    render json: GrpcRest.send_request("<%= service.namespace %>::<%= service.name.classify %>", "<%= method.name.underscore %>", grpc_request, <%= method.rest_options.inspect %>, headers: request.headers)
   end
 <% end %>
 end

--- a/lib/grpc_rest.rb
+++ b/lib/grpc_rest.rb
@@ -211,7 +211,7 @@ module GrpcRest
       end
     end
 
-    def send_gruf_request(klass, service_obj, method, request, headers: headers)
+    def send_gruf_request(klass, service_obj, method, request, headers: {})
       ref = service_obj.rpc_descs[method.classify.to_sym]
       call = GrpcRestCall.new(headers)
       handler = klass.new(

--- a/lib/grpc_rest.rb
+++ b/lib/grpc_rest.rb
@@ -5,6 +5,9 @@ require 'grpc'
 require 'grpc/core/status_codes'
 
 module GrpcRest
+
+  GrpcRestCall = Struct.new(:metadata)
+
   class << self
     attr_accessor :strict_mode
 
@@ -208,21 +211,29 @@ module GrpcRest
       end
     end
 
-    def send_gruf_request(klass, service_obj, method, request)
+    def send_gruf_request(klass, service_obj, method, request, headers: headers)
       ref = service_obj.rpc_descs[method.classify.to_sym]
+      call = GrpcRestCall.new(headers)
       handler = klass.new(
         method_key: method.to_sym,
         service: service_obj,
         rpc_desc: ref,
-        active_call: nil,
+        active_call: GrpcRestCall.new(headers),
         message: request
       )
-      Gruf::Interceptors::Context.new(gruf_interceptors(request)).intercept! do
+      controller_request = Gruf::Controllers::Request.new(
+        method_key: method.to_sym,
+        service: service_obj,
+        rpc_desc: ref,
+        active_call: call,
+        message: request
+      )
+      Gruf::Interceptors::Context.new(gruf_interceptors(controller_request)).intercept! do
         handler.send(method.to_sym)
       end
     end
 
-    # @param request [Google::Protobuf::AbstractMessage]
+    # @param request [Gruf::Controllers::Request]
     # @return [Array<Gruf::Interceptors::Base>]
     def gruf_interceptors(request)
       error = Gruf::Error.new
@@ -236,19 +247,19 @@ module GrpcRest
       klass.new.public_send(method, request)
     end
 
-    def get_response(service, method, request)
+    def get_response(service, method, request, headers: {})
       if defined?(Gruf)
         service_obj = service.constantize::Service
         klass = ::Gruf::Controllers::Base.subclasses.find do |k|
           k.bound_service == service_obj
         end
-        return send_gruf_request(klass, service_obj, method, request) if klass
+        return send_gruf_request(klass, service_obj, method, request, headers: headers) if klass
       end
       send_grpc_request(service, method, request)
     end
 
-    def send_request(service, method, request, options = {})
-      response = get_response(service, method, request)
+    def send_request(service, method, request, options = {}, headers: {})
+      response = get_response(service, method, request, headers: headers)
       if options[:emit_defaults]
         response.to_json(emit_defaults: true)
       else

--- a/spec/__snapshots__/service.snap
+++ b/spec/__snapshots__/service.snap
@@ -29,7 +29,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test"], "", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test", grpc_request, {:emit_defaults=>true})
+    render json: GrpcRest.send_request("Testdata::MyService", "test", grpc_request, {:emit_defaults=>true}, headers: request.headers)
   end
 
 	def test2
@@ -37,7 +37,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test2"], "second_record", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test2", grpc_request, {})
+    render json: GrpcRest.send_request("Testdata::MyService", "test2", grpc_request, {}, headers: request.headers)
   end
 
 	def test3
@@ -45,7 +45,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test3"], "", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test3", grpc_request, {})
+    render json: GrpcRest.send_request("Testdata::MyService", "test3", grpc_request, {}, headers: request.headers)
   end
 
 	def test4
@@ -53,7 +53,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test4"], "*", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test4", grpc_request, {})
+    render json: GrpcRest.send_request("Testdata::MyService", "test4", grpc_request, {}, headers: request.headers)
   end
 
 end

--- a/spec/testdata/base/app/controllers/my_service_controller.rb
+++ b/spec/testdata/base/app/controllers/my_service_controller.rb
@@ -28,7 +28,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test"], "", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test", grpc_request, {:emit_defaults=>true})
+    render json: GrpcRest.send_request("Testdata::MyService", "test", grpc_request, {:emit_defaults=>true}, headers: request.headers)
   end
 
 	def test2
@@ -36,7 +36,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test2"], "second_record", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test2", grpc_request, {})
+    render json: GrpcRest.send_request("Testdata::MyService", "test2", grpc_request, {}, headers: request.headers)
   end
 
 	def test3
@@ -44,7 +44,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test3"], "", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test3", grpc_request, {})
+    render json: GrpcRest.send_request("Testdata::MyService", "test3", grpc_request, {}, headers: request.headers)
   end
 
 	def test4
@@ -52,7 +52,7 @@ class MyServiceController < ActionController::Base
       except(*%w(controller action my_service))
     grpc_request = GrpcRest.init_request(Testdata::TestRequest, parameters)
     GrpcRest.assign_params(grpc_request, METHOD_PARAM_MAP["test4"], "*", request.parameters)
-    render json: GrpcRest.send_request("Testdata::MyService", "test4", grpc_request, {})
+    render json: GrpcRest.send_request("Testdata::MyService", "test4", grpc_request, {}, headers: request.headers)
   end
 
 end


### PR DESCRIPTION
Fix/Change: Update interceptors to pass a Gruf::Controller::Request instead of the raw gRPC request object. This allows e.g. checking metadata inside the interceptor. This is a breaking change.